### PR TITLE
Update Neo4jResourceBuilderExtensions.cs

### DIFF
--- a/src/Hosting/Neo4jResourceBuilderExtensions.cs
+++ b/src/Hosting/Neo4jResourceBuilderExtensions.cs
@@ -42,7 +42,7 @@ public static class Neo4jResourceBuilderExtensions
             .WithImage(Neo4jContainerImageTags.Image)
             .WithImageRegistry(Neo4jContainerImageTags.Registry)
             .WithImageTag(Neo4jContainerImageTags.Tag)
-            .WithEnvironment(AuthEnvVarName, $"{graphDb.UsernameParameter.Value}/{graphDb.PasswordParameter.Value}")
+            .WithEnvironment(AuthEnvVarName, $"{graphDb.UsernameParameter}/{graphDb.PasswordParameter}")
             .WithEndpoint(
                         targetPort: boltPort,
                         port: 7687,


### PR DESCRIPTION
Use the parameter in the expression instead of resolving the value directly. This will make it work in publish mode and won't burn in the value of the parameter.